### PR TITLE
[BE] 내 정보 수정 API 추가

### DIFF
--- a/server/module-api/src/docs/asciidoc/user.adoc
+++ b/server/module-api/src/docs/asciidoc/user.adoc
@@ -47,7 +47,7 @@ operation::user/findParticipatingGroups[snippets='http-request,http-response,res
 
 === 내 정보 수정
 
-operation::user/update[snippets='http-request,http-response,request-fields']
+operation::user/updateMyInformation[snippets='http-request,http-response,request-parameters,request-parts']
 
 === 관심 카테고리 수정
 

--- a/server/module-api/src/docs/asciidoc/user.adoc
+++ b/server/module-api/src/docs/asciidoc/user.adoc
@@ -45,9 +45,13 @@ operation::user/findParticipatingGroupCount[snippets='http-request,http-response
 
 operation::user/findParticipatingGroups[snippets='http-request,http-response,response-fields']
 
-=== 내 정보 수정
+=== 내 정보 수정 (이미지가 없는 경우)
 
-operation::user/updateMyInformation[snippets='http-request,http-response,request-parameters,request-parts']
+operation::user/updateMyInformation[snippets='http-request,http-response,request-parameters']
+
+=== 내 정보 수정 (이미지가 있는 경우)
+
+operation::user/updateMyInformationWithImage[snippets='http-request,http-response,request-parameters,request-parts']
 
 === 관심 카테고리 수정
 

--- a/server/module-api/src/main/java/com/momo/api/user/UserController.java
+++ b/server/module-api/src/main/java/com/momo/api/user/UserController.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -87,8 +88,8 @@ public class UserController {
     }
 
     @PatchMapping
-    public ResponseEntity<Void> update(@CurrentUser User user,
-        @Valid @RequestBody UserUpdateRequest userUpdateRequest) {
+    public ResponseEntity<Void> updateMyInformation(@CurrentUser User user,
+        @Valid @ModelAttribute UserUpdateRequest userUpdateRequest) {
         userService.update(user, userUpdateRequest);
         return ResponseEntity.ok().build();
     }

--- a/server/module-api/src/main/java/com/momo/api/user/UserController.java
+++ b/server/module-api/src/main/java/com/momo/api/user/UserController.java
@@ -40,6 +40,13 @@ public class UserController {
     private final FavoriteGroupService favoriteGroupService;
     private final GroupManagementService groupManagementService;
 
+    @PostMapping("/update")
+    public ResponseEntity<Void> updateMyInformation(@CurrentUser User user,
+        @Valid @ModelAttribute UserUpdateRequest userUpdateRequest) {
+        userService.update(user, userUpdateRequest);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/favorite-group")
     public ResponseEntity<Void> createFavoriteGroup(@CurrentUser User user,
         @Valid @RequestBody FavoriteGroupCreateRequest request) throws URISyntaxException {
@@ -85,13 +92,6 @@ public class UserController {
     public ResponseEntity<List<ParticipatingGroupCardResponse>> findParticipatingGroups(@CurrentUser User user) {
         List<ParticipatingGroupCardResponse> responses = groupManagementService.findParticipatingGroupsByUser(user);
         return ResponseEntity.ok(responses);
-    }
-
-    @PatchMapping
-    public ResponseEntity<Void> updateMyInformation(@CurrentUser User user,
-        @Valid @ModelAttribute UserUpdateRequest userUpdateRequest) {
-        userService.update(user, userUpdateRequest);
-        return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/favorite-categories")

--- a/server/module-api/src/test/java/com/momo/auth/docs/OAuthRestDocsTest.java
+++ b/server/module-api/src/test/java/com/momo/auth/docs/OAuthRestDocsTest.java
@@ -33,7 +33,7 @@ public class OAuthRestDocsTest extends RestDocsControllerTest {
         String content = super.objectMapper.writeValueAsString(request);
         super.mockMvc.perform(post("/api/oauth/login")
                 .content(content)
-                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andDo(OAuthDocumentation.oauthLogin());
@@ -48,7 +48,7 @@ public class OAuthRestDocsTest extends RestDocsControllerTest {
         String content = super.objectMapper.writeValueAsString(request);
         super.mockMvc.perform(post("/api/oauth/login/refresh")
                 .content(content)
-                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andDo(OAuthDocumentation.refreshLogin());

--- a/server/module-api/src/test/java/com/momo/group/docs/ParticipantRestDocsTest.java
+++ b/server/module-api/src/test/java/com/momo/group/docs/ParticipantRestDocsTest.java
@@ -38,7 +38,7 @@ public class ParticipantRestDocsTest extends RestDocsControllerTest {
 
         super.mockMvc.perform(post("/api/group/apply-participant")
                 .content(content)
-                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isOk())
             .andDo(ParticipantDocumenttation.applyParticipantByGroup());

--- a/server/module-api/src/test/java/com/momo/post/docs/CommentRestDocsTest.java
+++ b/server/module-api/src/test/java/com/momo/post/docs/CommentRestDocsTest.java
@@ -49,7 +49,7 @@ public class CommentRestDocsTest extends RestDocsControllerTest {
         String content = super.objectMapper.writeValueAsString(request);
         super.mockMvc.perform(post("/api/comment")
                 .content(content)
-                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isCreated())
             .andDo(CommentDocumentation.create());

--- a/server/module-api/src/test/java/com/momo/schedule/docs/AttendanceRestDocsTest.java
+++ b/server/module-api/src/test/java/com/momo/schedule/docs/AttendanceRestDocsTest.java
@@ -37,7 +37,7 @@ public class AttendanceRestDocsTest extends RestDocsControllerTest {
         String content = super.objectMapper.writeValueAsString(requests);
         super.mockMvc.perform(post("/api/attendance")
                 .content(content)
-                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isCreated())
             .andDo(AttendanceDocumentation.create());

--- a/server/module-api/src/test/java/com/momo/schedule/docs/ScheduleRestDocsTest.java
+++ b/server/module-api/src/test/java/com/momo/schedule/docs/ScheduleRestDocsTest.java
@@ -47,7 +47,7 @@ public class ScheduleRestDocsTest extends RestDocsControllerTest {
         String content = super.objectMapper.writeValueAsString(request);
         super.mockMvc.perform(post("/api/schedule")
                 .content(content)
-                .contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+                .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andDo(print())
             .andExpect(status().isCreated())
             .andDo(ScheduleDocumentation.create());

--- a/server/module-api/src/test/java/com/momo/user/acceptance/UserAcceptanceTest.java
+++ b/server/module-api/src/test/java/com/momo/user/acceptance/UserAcceptanceTest.java
@@ -8,11 +8,13 @@ import static com.momo.fixture.GroupFixture.GROUP_CREATE_REQUEST1;
 import static com.momo.fixture.GroupFixture.GROUP_CREATE_REQUEST2;
 import static com.momo.fixture.UserFixture.getUser1;
 import static com.momo.group.acceptance.step.GroupAcceptanceStep.requestToCreateGroup;
+import static com.momo.user.acceptance.step.UserAcceptanceStep.assertThatFindFavoriteCategories;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.assertThatFindFavoriteGroups;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.assertThatFindMyInformation;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.assertThatFindParticipatingGroups;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToCreateFavoriteGroup;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToDeleteFavoriteGroup;
+import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindFavoriteCategories;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindFavoriteGroupCount;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindFavoriteGroups;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindMyInformation;
@@ -23,6 +25,7 @@ import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToUpdateFa
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.momo.common.acceptance.AcceptanceTest;
+import com.momo.domain.common.dto.EnumResponse;
 import com.momo.domain.district.entity.City;
 import com.momo.domain.group.entity.Category;
 import com.momo.domain.user.dto.FavoriteCategoriesUpdateRequest;
@@ -81,6 +84,18 @@ public class UserAcceptanceTest extends AcceptanceTest {
         List<FavoriteGroupCardResponse> favoriteGroupResponses = getObjects(response, FavoriteGroupCardResponse.class);
         assertThatStatusIsOk(response);
         assertThatFindFavoriteGroups(favoriteGroupResponses, GROUP_CREATE_REQUEST1);
+    }
+
+    @Test
+    void 관심_카테고리_목록을_조회한다() {
+        FavoriteCategoriesUpdateRequest request = new FavoriteCategoriesUpdateRequest(
+            List.of(Category.HEALTH, Category.EMPLOYMENT)
+        );
+        String token = getAccessToken(getUser1());
+        requestToUpdateFavoriteCategories(token, request);
+        ExtractableResponse<Response> response = requestToFindFavoriteCategories(token);
+        assertThatStatusIsOk(response);
+        assertThatFindFavoriteCategories(getObjects(response, EnumResponse.class), request);
     }
 
     @Test

--- a/server/module-api/src/test/java/com/momo/user/acceptance/UserAcceptanceTest.java
+++ b/server/module-api/src/test/java/com/momo/user/acceptance/UserAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.momo.user.acceptance;
 
+import static com.momo.CommonFileUploadSupport.uploadTestFile;
 import static com.momo.common.acceptance.step.AcceptanceStep.assertThatStatusIsBadRequest;
 import static com.momo.common.acceptance.step.AcceptanceStep.assertThatStatusIsCreated;
 import static com.momo.common.acceptance.step.AcceptanceStep.assertThatStatusIsNoContent;
@@ -12,6 +13,8 @@ import static com.momo.user.acceptance.step.UserAcceptanceStep.assertThatFindFav
 import static com.momo.user.acceptance.step.UserAcceptanceStep.assertThatFindFavoriteGroups;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.assertThatFindMyInformation;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.assertThatFindParticipatingGroups;
+import static com.momo.user.acceptance.step.UserAcceptanceStep.assertThatUpdateMyInformation;
+import static com.momo.user.acceptance.step.UserAcceptanceStep.assertThatUpdateMyInformationWithImage;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToCreateFavoriteGroup;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToDeleteFavoriteGroup;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindFavoriteCategories;
@@ -20,8 +23,8 @@ import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindFavo
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindMyInformation;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindParticipatingGroupCount;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindParticipatingGroups;
-import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToUpdate;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToUpdateFavoriteCategories;
+import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToUpdateMyInformation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.momo.common.acceptance.AcceptanceTest;
@@ -120,7 +123,24 @@ public class UserAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 내_정보를_수정한다() {
+    void 내_정보를_수정한다_이미지_O() {
+        UserUpdateRequest userUpdateRequest = UserUpdateRequest.builder()
+            .nickname("모모")
+            .university("한국대학교")
+            .city(City.SEOUL)
+            .district("강동구")
+            .image(uploadTestFile)
+            .build();
+        String token = getAccessToken(getUser1());
+        ExtractableResponse<Response> response = requestToUpdateMyInformation(token, userUpdateRequest);
+        UserResponse userResponse = getObject(requestToFindMyInformation(token), UserResponse.class);
+        assertThatStatusIsOk(response);
+        assertThatUpdateMyInformationWithImage(userResponse, userUpdateRequest);
+    }
+
+    @Test
+    @Disabled
+    void 내_정보를_수정한다_이미지_X() {
         UserUpdateRequest userUpdateRequest = UserUpdateRequest.builder()
             .nickname("모모")
             .university("한국대학교")
@@ -128,17 +148,20 @@ public class UserAcceptanceTest extends AcceptanceTest {
             .district("강동구")
             .build();
         String token = getAccessToken(getUser1());
-        ExtractableResponse<Response> response = requestToUpdate(token, userUpdateRequest);
+        ExtractableResponse<Response> response = requestToUpdateMyInformation(token, userUpdateRequest);
+        UserResponse userResponse = getObject(requestToFindMyInformation(token), UserResponse.class);
         assertThatStatusIsOk(response);
+        assertThatUpdateMyInformation(userResponse, userUpdateRequest);
     }
 
     @Test
     void 내_정보를_수정할_때_입력값이_공백_또는_널이면_실패한다() {
         UserUpdateRequest userUpdateRequest = UserUpdateRequest.builder()
             .nickname(" ")
+            .image(uploadTestFile)
             .build();
         String token = getAccessToken(getUser1());
-        ExtractableResponse<Response> response = requestToUpdate(token, userUpdateRequest);
+        ExtractableResponse<Response> response = requestToUpdateMyInformation(token, userUpdateRequest);
         assertThatStatusIsBadRequest(response);
     }
 

--- a/server/module-api/src/test/java/com/momo/user/acceptance/UserAcceptanceTest.java
+++ b/server/module-api/src/test/java/com/momo/user/acceptance/UserAcceptanceTest.java
@@ -25,6 +25,7 @@ import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindPart
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToFindParticipatingGroups;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToUpdateFavoriteCategories;
 import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToUpdateMyInformation;
+import static com.momo.user.acceptance.step.UserAcceptanceStep.requestToUpdateMyInformationWithImage;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.momo.common.acceptance.AcceptanceTest;
@@ -123,7 +124,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 내_정보를_수정한다_이미지_O() {
+    void 내_정보를_수정한다_이미지_포함() {
         UserUpdateRequest userUpdateRequest = UserUpdateRequest.builder()
             .nickname("모모")
             .university("한국대학교")
@@ -132,15 +133,14 @@ public class UserAcceptanceTest extends AcceptanceTest {
             .image(uploadTestFile)
             .build();
         String token = getAccessToken(getUser1());
-        ExtractableResponse<Response> response = requestToUpdateMyInformation(token, userUpdateRequest);
+        ExtractableResponse<Response> response = requestToUpdateMyInformationWithImage(token, userUpdateRequest);
         UserResponse userResponse = getObject(requestToFindMyInformation(token), UserResponse.class);
         assertThatStatusIsOk(response);
         assertThatUpdateMyInformationWithImage(userResponse, userUpdateRequest);
     }
 
     @Test
-    @Disabled
-    void 내_정보를_수정한다_이미지_X() {
+    void 내_정보를_수정한다_이미지_미포함() {
         UserUpdateRequest userUpdateRequest = UserUpdateRequest.builder()
             .nickname("모모")
             .university("한국대학교")
@@ -155,10 +155,9 @@ public class UserAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 내_정보를_수정할_때_입력값이_공백_또는_널이면_실패한다() {
+    void 내_정보를_수정할_때_입력값이_공백_또는_널이면_실패한다_이미지_미포함() {
         UserUpdateRequest userUpdateRequest = UserUpdateRequest.builder()
             .nickname(" ")
-            .image(uploadTestFile)
             .build();
         String token = getAccessToken(getUser1());
         ExtractableResponse<Response> response = requestToUpdateMyInformation(token, userUpdateRequest);

--- a/server/module-api/src/test/java/com/momo/user/acceptance/step/UserAcceptanceStep.java
+++ b/server/module-api/src/test/java/com/momo/user/acceptance/step/UserAcceptanceStep.java
@@ -51,8 +51,8 @@ public class UserAcceptanceStep {
         Assertions.assertAll(
             () -> assertThat(responses.size()).isEqualTo(1),
             () -> assertThat(responses.get(0).getId()).isNotNull(),
+            () -> assertThat(responses.get(0).getImageUrl()).isNotNull(),
             () -> assertThat(responses.get(0).getName()).isEqualTo(request.getName()),
-            () -> assertThat(responses.get(0).getImageUrl()).isEqualTo(request.getImageUrl()),
             () -> assertThat(responses.get(0).getStartDate()).isEqualTo(request.getStartDate()),
             () -> assertThat(responses.get(0).isOffline()).isEqualTo(request.getIsOffline()),
             () -> assertThat(responses.get(0).isEnd()).isFalse(),

--- a/server/module-api/src/test/java/com/momo/user/acceptance/step/UserAcceptanceStep.java
+++ b/server/module-api/src/test/java/com/momo/user/acceptance/step/UserAcceptanceStep.java
@@ -3,6 +3,7 @@ package com.momo.user.acceptance.step;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.momo.domain.common.dto.EnumResponse;
 import com.momo.domain.group.dto.GroupCreateRequest;
 import com.momo.domain.user.dto.FavoriteCategoriesUpdateRequest;
 import com.momo.domain.user.dto.FavoriteGroupCardResponse;
@@ -43,6 +44,17 @@ public class UserAcceptanceStep {
             () -> assertThat(responses.get(0).getGroupCardResponse().getStartDate()).isEqualTo(request.getStartDate()),
             () -> assertThat(responses.get(0).getGroupCardResponse().getImageUrl()).isNotNull(),
             () -> assertThat(responses.get(0).getGroupCardResponse().getParticipantCnt()).isEqualTo(1)
+        );
+    }
+
+    public static void assertThatFindFavoriteCategories(List<EnumResponse> responses,
+        FavoriteCategoriesUpdateRequest request) {
+        Assertions.assertAll(
+            () -> assertThat(responses.size()).isEqualTo(request.getFavoriteCategories().size()),
+            () -> assertThat(responses.get(0).getName()).isEqualTo(request.getFavoriteCategories().get(0).getName()),
+            () -> assertThat(responses.get(0).getCode()).isEqualTo(request.getFavoriteCategories().get(0).getCode()),
+            () -> assertThat(responses.get(1).getName()).isEqualTo(request.getFavoriteCategories().get(1).getName()),
+            () -> assertThat(responses.get(1).getCode()).isEqualTo(request.getFavoriteCategories().get(1).getCode())
         );
     }
 
@@ -95,6 +107,15 @@ public class UserAcceptanceStep {
             .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
             .when()
             .get("/api/user/favorite-groups")
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> requestToFindFavoriteCategories(String token) {
+        return given().log().all()
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+            .when()
+            .get("/api/user/favorite-categories")
             .then().log().all()
             .extract();
     }

--- a/server/module-api/src/test/java/com/momo/user/acceptance/step/UserAcceptanceStep.java
+++ b/server/module-api/src/test/java/com/momo/user/acceptance/step/UserAcceptanceStep.java
@@ -165,6 +165,16 @@ public class UserAcceptanceStep {
         UserUpdateRequest userUpdateRequest) {
         return uploadAssuredSupport(
             given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token), userUpdateRequest)
+            .post("/api/user/update")
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> requestToUpdateMyInformationWithImage(String token,
+        UserUpdateRequest userUpdateRequest) {
+        return uploadAssuredSupport(
+            given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .contentType(MediaType.MULTIPART_FORM_DATA_VALUE), userUpdateRequest)
             .post("/api/user/update")

--- a/server/module-api/src/test/java/com/momo/user/acceptance/step/UserAcceptanceStep.java
+++ b/server/module-api/src/test/java/com/momo/user/acceptance/step/UserAcceptanceStep.java
@@ -1,5 +1,6 @@
 package com.momo.user.acceptance.step;
 
+import static com.momo.CommonFileUploadSupport.uploadAssuredSupport;
 import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -72,6 +73,28 @@ public class UserAcceptanceStep {
         );
     }
 
+    public static void assertThatUpdateMyInformation(UserResponse response, UserUpdateRequest request) {
+        Assertions.assertAll(
+            () -> assertThat(response.getId()).isNotNull(),
+            () -> assertThat(response.getImage()).isNull(),
+            () -> assertThat(response.getCity()).isNotNull(),
+            () -> assertThat(response.getNickname()).isEqualTo(request.getNickname()),
+            () -> assertThat(response.getUniversity()).isEqualTo(request.getUniversity()),
+            () -> assertThat(response.getDistrict()).isEqualTo(request.getDistrict())
+        );
+    }
+
+    public static void assertThatUpdateMyInformationWithImage(UserResponse response, UserUpdateRequest request) {
+        Assertions.assertAll(
+            () -> assertThat(response.getId()).isNotNull(),
+            () -> assertThat(response.getImage()).isNotNull(),
+            () -> assertThat(response.getCity()).isNotNull(),
+            () -> assertThat(response.getNickname()).isEqualTo(request.getNickname()),
+            () -> assertThat(response.getUniversity()).isEqualTo(request.getUniversity()),
+            () -> assertThat(response.getDistrict()).isEqualTo(request.getDistrict())
+        );
+    }
+
     public static ExtractableResponse<Response> requestToCreateFavoriteGroup(String token,
         FavoriteGroupCreateRequest request) {
         return given().log().all()
@@ -138,14 +161,13 @@ public class UserAcceptanceStep {
             .extract();
     }
 
-    public static ExtractableResponse<Response> requestToUpdate(String token,
+    public static ExtractableResponse<Response> requestToUpdateMyInformation(String token,
         UserUpdateRequest userUpdateRequest) {
-        return given().log().all()
-            .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .body(userUpdateRequest)
-            .when()
-            .patch("/api/user")
+        return uploadAssuredSupport(
+            given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                .contentType(MediaType.MULTIPART_FORM_DATA_VALUE), userUpdateRequest)
+            .post("/api/user/update")
             .then().log().all()
             .extract();
     }

--- a/server/module-api/src/test/java/com/momo/user/docs/UserDocumentation.java
+++ b/server/module-api/src/test/java/com/momo/user/docs/UserDocumentation.java
@@ -124,10 +124,22 @@ public class UserDocumentation {
             parameterWithName("city").description("유저 거주 도시"),
             parameterWithName("district").description("유저 거주 지역")
         };
+        return document("user/updateMyInformation",
+            requestParameters(requestUser)
+        );
+    }
+
+    public static RestDocumentationResultHandler updateMyInformationWithImage() {
+        ParameterDescriptor[] requestUser = new ParameterDescriptor[]{
+            parameterWithName("nickname").description("유저 닉네임"),
+            parameterWithName("university").description("유저 학교"),
+            parameterWithName("city").description("유저 거주 도시"),
+            parameterWithName("district").description("유저 거주 지역")
+        };
         RequestPartDescriptor[] requestPart = new RequestPartDescriptor[]{
             partWithName("image").description("유저 프로필 이미지")
         };
-        return document("user/updateMyInformation",
+        return document("user/updateMyInformationWithImage",
             requestParameters(requestUser),
             requestParts(requestPart)
         );

--- a/server/module-api/src/test/java/com/momo/user/docs/UserDocumentation.java
+++ b/server/module-api/src/test/java/com/momo/user/docs/UserDocumentation.java
@@ -5,13 +5,16 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.request.ParameterDescriptor;
+import org.springframework.restdocs.request.RequestPartDescriptor;
 
 public class UserDocumentation {
 
@@ -114,15 +117,19 @@ public class UserDocumentation {
         );
     }
 
-    public static RestDocumentationResultHandler update() {
-        FieldDescriptor[] requestUser = new FieldDescriptor[]{
-            fieldWithPath("nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
-            fieldWithPath("university").type(JsonFieldType.STRING).description("유저 학교"),
-            fieldWithPath("city").type(JsonFieldType.STRING).description("유저 거주 도시"),
-            fieldWithPath("district").type(JsonFieldType.STRING).description("유저 거주 지역")
+    public static RestDocumentationResultHandler updateMyInformation() {
+        ParameterDescriptor[] requestUser = new ParameterDescriptor[]{
+            parameterWithName("nickname").description("유저 닉네임"),
+            parameterWithName("university").description("유저 학교"),
+            parameterWithName("city").description("유저 거주 도시"),
+            parameterWithName("district").description("유저 거주 지역")
         };
-        return document("user/update",
-            requestFields(requestUser)
+        RequestPartDescriptor[] requestPart = new RequestPartDescriptor[]{
+            partWithName("image").description("유저 프로필 이미지")
+        };
+        return document("user/updateMyInformation",
+            requestParameters(requestUser),
+            requestParts(requestPart)
         );
     }
 

--- a/server/module-api/src/test/java/com/momo/user/docs/UserRestDocsTest.java
+++ b/server/module-api/src/test/java/com/momo/user/docs/UserRestDocsTest.java
@@ -183,7 +183,26 @@ public class UserRestDocsTest extends RestDocsControllerTest {
     }
 
     @Test
-    void 내_정보_수정() throws Exception {
+    void 내_정보_수정_이미지_미포함() throws Exception {
+        UserUpdateRequest request = UserUpdateRequest.builder()
+            .nickname("테스트 이름")
+            .university("한국대")
+            .city(City.SEOUL)
+            .district("마포구")
+            .build();
+        super.mockMvc.perform(post("/api/user/update")
+                .param("nickname", request.getNickname())
+                .param("university", request.getUniversity())
+                .param("city", request.getCity().getCode())
+                .param("district", request.getDistrict())
+            )
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andDo(UserDocumentation.updateMyInformation());
+    }
+
+    @Test
+    void 내_정보_수정_이미지_포함() throws Exception {
         UserUpdateRequest request = UserUpdateRequest.builder()
             .nickname("테스트 이름")
             .university("한국대")
@@ -194,7 +213,7 @@ public class UserRestDocsTest extends RestDocsControllerTest {
         super.mockMvc.perform(uploadMockSupport(fileUpload("/api/user/update"), request))
             .andDo(print())
             .andExpect(status().isOk())
-            .andDo(UserDocumentation.updateMyInformation());
+            .andDo(UserDocumentation.updateMyInformationWithImage());
     }
 
     @Test

--- a/server/module-api/src/test/java/com/momo/user/docs/UserRestDocsTest.java
+++ b/server/module-api/src/test/java/com/momo/user/docs/UserRestDocsTest.java
@@ -1,8 +1,10 @@
 package com.momo.user.docs;
 
+import static com.momo.CommonFileUploadSupport.uploadMockSupport;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.fileUpload;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -34,6 +36,7 @@ import org.mockito.InjectMocks;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 
 @WebMvcTest(UserController.class)
 @DisplayName("사용자 문서화 테스트")
@@ -186,15 +189,12 @@ public class UserRestDocsTest extends RestDocsControllerTest {
             .university("한국대")
             .city(City.SEOUL)
             .district("마포구")
+            .image(new MockMultipartFile("image", "image".getBytes()))
             .build();
-        String content = super.objectMapper.writeValueAsString(request);
-        super.mockMvc.perform(patch("/api/user")
-                .content(content)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-            )
+        super.mockMvc.perform(uploadMockSupport(fileUpload("/api/user/update"), request))
             .andDo(print())
             .andExpect(status().isOk())
-            .andDo(UserDocumentation.update());
+            .andDo(UserDocumentation.updateMyInformation());
     }
 
     @Test

--- a/server/module-core/src/main/java/com/momo/domain/aws/service/S3UploadService.java
+++ b/server/module-core/src/main/java/com/momo/domain/aws/service/S3UploadService.java
@@ -2,9 +2,12 @@ package com.momo.domain.aws.service;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.momo.domain.aws.infra.S3Uploader;
+import com.momo.domain.common.exception.CustomException;
+import com.momo.domain.common.exception.ErrorCode;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,13 +21,21 @@ public class S3UploadService implements ImageUploadService {
 
     private final S3Uploader s3Uploader;
 
-    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+    public String upload(MultipartFile multipartFile, String dirName) {
+        if (Objects.isNull(multipartFile)) {
+            return null;
+        }
+
         String fileName = generateSaveFileName(dirName, multipartFile.getName());
         ObjectMetadata metadata = generateObjectMeta(multipartFile.getContentType(), multipartFile.getSize());
-        return s3Uploader.save(fileName, multipartFile.getInputStream(), metadata);
+        try {
+            return s3Uploader.save(fileName, multipartFile.getInputStream(), metadata);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.IMAGE_FILE_UPLOAD_ERROR);
+        }
     }
 
-    public List<String> uploadAll(List<MultipartFile> multipartFiles, String dirName) throws IOException {
+    public List<String> uploadAll(List<MultipartFile> multipartFiles, String dirName) {
         List<String> uploadUrls = new ArrayList<>();
         for (MultipartFile multipartFile : multipartFiles) {
             String uploadImageUrl = upload(multipartFile, dirName);

--- a/server/module-core/src/main/java/com/momo/domain/common/dto/EnumResponse.java
+++ b/server/module-core/src/main/java/com/momo/domain/common/dto/EnumResponse.java
@@ -40,7 +40,7 @@ public class EnumResponse {
             .collect(Collectors.toList());
     }
 
-    public static List<EnumResponse> listFromCategories(FavoriteCategories favoriteCategories) {
+    public static List<EnumResponse> listOfFavoriteCategories(FavoriteCategories favoriteCategories) {
         return favoriteCategories.toCategories()
             .stream()
             .map(EnumResponse::ofCategory)

--- a/server/module-core/src/main/java/com/momo/domain/common/exception/ErrorCode.java
+++ b/server/module-core/src/main/java/com/momo/domain/common/exception/ErrorCode.java
@@ -9,8 +9,9 @@ public enum ErrorCode {
     CAREER_NET_SERVER_ERROR(500, "커리어넷 서버에 문제가 생겼습니다"),
     PARSING_DISTRICT_FILE_ERROR(500, "행정구역 파일을 읽는 과정에서 문제가 생겼습니다"),
     CITY_CATEGORY_NAME_NOT_FOUND(500, "지역(시/도) 카테고리 타입이 존재하지 않습니다."),
+    IMAGE_FILE_UPLOAD_ERROR(500, "이미지 파일을 업로드하는 과정에서 문제가 생겼습니다."),
 
-    INVALID_OAUTH_AUTHORIZATION_CODE(4001, "유효하지 않은 OAuth 인가 코드 입니다."),
+    INVALID_OAUTH_AUTHORIZATION_CODE(401, "유효하지 않은 OAuth 인가 코드 입니다."),
     INVALID_OAUTH_ACCESS_TOKEN(401, "유효하지 않은 OAuth 엑세스 토큰입니다."),
     INVALID_ACCESS_TOKEN(401, "유효하지 않은 엑세스 토큰입니다."),
     INVALID_REFRESH_TOKEN(401, "유효하지 않은 리프레쉬 토큰입니다."),

--- a/server/module-core/src/main/java/com/momo/domain/user/dto/UserResponse.java
+++ b/server/module-core/src/main/java/com/momo/domain/user/dto/UserResponse.java
@@ -39,7 +39,7 @@ public class UserResponse {
             .city(EnumResponse.ofCity(user.getCity()))
             .district(user.getDistrict())
             .university(user.getUniversity())
-            .categories(EnumResponse.listFromCategories(user.getFavoriteCategories()))
+            .categories(EnumResponse.listOfFavoriteCategories(user.getFavoriteCategories()))
             .build();
     }
 }

--- a/server/module-core/src/main/java/com/momo/domain/user/dto/UserUpdateRequest.java
+++ b/server/module-core/src/main/java/com/momo/domain/user/dto/UserUpdateRequest.java
@@ -8,6 +8,7 @@ import javax.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @NoArgsConstructor
@@ -26,12 +27,15 @@ public class UserUpdateRequest {
     @NotBlank(message = "사는 지역은 필수 입력값입니다.")
     private String district;
 
+    private MultipartFile image;
+
     @Builder
-    public UserUpdateRequest(String nickname, String university, City city, String district) {
+    public UserUpdateRequest(String nickname, String university, City city, String district, MultipartFile image) {
         this.nickname = nickname;
         this.university = university;
         this.city = city;
         this.district = district;
+        this.image = image;
     }
 
     public User toEntity() {

--- a/server/module-core/src/main/java/com/momo/domain/user/entity/User.java
+++ b/server/module-core/src/main/java/com/momo/domain/user/entity/User.java
@@ -74,22 +74,23 @@ public class User extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
-    public boolean isNotSameNickname(String nickname) {
+    public boolean isSameNickname(String nickname) {
         if (Objects.isNull(this.nickname)) {
             return true;
         }
-        return !this.nickname.equals(nickname);
+        return this.nickname.equals(nickname);
     }
 
     public boolean isSameUser(User user) {
         return id.equals(user.getId());
     }
 
-    public void update(User user) {
+    public void update(User user, String imageUrl) {
         this.nickname = user.getNickname();
         this.city = user.getCity();
         this.district = user.getDistrict();
         this.university = user.getUniversity();
+        this.imageUrl = imageUrl;
     }
 
     public void updateFavoriteCategories(List<Category> categories) {

--- a/server/module-core/src/main/java/com/momo/domain/user/service/UserService.java
+++ b/server/module-core/src/main/java/com/momo/domain/user/service/UserService.java
@@ -5,6 +5,7 @@ import com.momo.domain.common.exception.CustomException;
 import com.momo.domain.common.exception.ErrorCode;
 import com.momo.domain.user.dto.FavoriteCategoriesUpdateRequest;
 import com.momo.domain.user.dto.UserUpdateRequest;
+import com.momo.domain.user.entity.FavoriteCategories;
 import com.momo.domain.user.entity.User;
 import com.momo.domain.user.repository.UserRepository;
 import java.util.List;
@@ -33,14 +34,10 @@ public class UserService {
         }
     }
 
+    @Transactional(readOnly = true)
     public List<EnumResponse> findFavoriteCategoriesByUser(User loginUser) {
-        /*
-        TODO
-        @CurrentUser 로 유저 엔티티 조회시 관심 카테고리도 함께 조회하고 있음.
-        쿼리 개선이 필요.
-        쿼리 개선을 하면 관심 카테고리 조회 로직도 변경되어야함.
-        */
-        return EnumResponse.listFromCategories(loginUser.getFavoriteCategories());
+        FavoriteCategories favoriteCategories = loginUser.getFavoriteCategories();
+        return EnumResponse.listOfFavoriteCategories(favoriteCategories);
     }
 
     public void updateFavoriteCategories(User loginUser, FavoriteCategoriesUpdateRequest request) {

--- a/server/module-core/src/test/java/com/momo/domain/user/entity/UserTest.java
+++ b/server/module-core/src/test/java/com/momo/domain/user/entity/UserTest.java
@@ -28,17 +28,17 @@ public class UserTest {
     }
 
     @Test
-    void 유저_닉네임이_널인_경우_다른_닉네임_중복_확인_테스트() {
+    void 유저_닉네임이_널인_경우_같은_닉네임_확인_테스트() {
         User user = User.builder().build();
-        boolean expected = user.isNotSameNickname("nickname");
+        boolean expected = user.isSameNickname("nickname");
         assertThat(expected).isTrue();
     }
 
     @Test
-    void 유저_닉네임이_널이_아닌_경우_닉네임_중복_확인_테스트() {
+    void 유저_닉네임이_널이_아닌_경우_같은_닉네임_확인_테스트() {
         User user = User.builder().nickname("nickname").build();
-        boolean expected = user.isNotSameNickname("nickname");
-        assertThat(expected).isFalse();
+        boolean expected = user.isSameNickname("nickname");
+        assertThat(expected).isTrue();
     }
 
     @Test

--- a/server/module-core/src/test/java/com/momo/domain/user/service/UserServiceTest.java
+++ b/server/module-core/src/test/java/com/momo/domain/user/service/UserServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.momo.common.ServiceTest;
+import com.momo.domain.aws.service.S3UploadService;
 import com.momo.domain.common.dto.EnumResponse;
 import com.momo.domain.common.exception.CustomException;
 import com.momo.domain.common.exception.ErrorCode;
@@ -18,6 +19,7 @@ import com.momo.domain.user.dto.FavoriteCategoriesUpdateRequest;
 import com.momo.domain.user.dto.UserUpdateRequest;
 import com.momo.domain.user.entity.User;
 import com.momo.domain.user.repository.UserRepository;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,12 +27,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.mock.web.MockMultipartFile;
 
 @DisplayName("유저 서비스 테스트")
 public class UserServiceTest extends ServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private S3UploadService s3UploadService;
 
     @InjectMocks
     private UserService userService;
@@ -46,7 +52,7 @@ public class UserServiceTest extends ServiceTest {
     }
 
     @Test
-    void 변경할_닉네임이_다른_경우_유저_정보_업데이트_테스트() {
+    void 변경할_닉네임이_다른_경우_유저_정보를_수정한다_이미지_NULL() {
         UserUpdateRequest userUpdateRequest = UserUpdateRequest.builder()
             .nickname("변경할 닉네임")
             .university("변경할 대학교")
@@ -56,39 +62,47 @@ public class UserServiceTest extends ServiceTest {
 
         given(userRepository.findById(any())).willReturn(of(user));
         given(userRepository.existsByNickname(any())).willReturn(false);
+        given(s3UploadService.upload(any(), any())).willReturn(null);
 
         userService.update(user, userUpdateRequest);
 
         verify(userRepository).findById(any());
         verify(userRepository).existsByNickname(any());
+        verify(s3UploadService).upload(any(), any());
         Assertions.assertAll(
             () -> assertThat(user.getNickname()).isEqualTo(userUpdateRequest.getNickname()),
             () -> assertThat(user.getUniversity()).isEqualTo(userUpdateRequest.getUniversity()),
             () -> assertThat(user.getCity()).isEqualTo(userUpdateRequest.getCity()),
-            () -> assertThat(user.getDistrict()).isEqualTo(userUpdateRequest.getDistrict())
+            () -> assertThat(user.getDistrict()).isEqualTo(userUpdateRequest.getDistrict()),
+            () -> assertThat(user.getImageUrl()).isNull()
         );
     }
 
     @Test
-    void 변경할_닉네임이_같은_경우_유저_정보_업데이트_테스트() {
+    void 변경할_닉네임이_같은_경우_유저_정보를_수정한다_이미지_NOT_NULL() {
+        String imageUrl = "imageUrl";
         UserUpdateRequest userUpdateRequest = UserUpdateRequest.builder()
-            .nickname("닉네임")
+            .nickname(user.getNickname())
             .university("변경할 대학교")
             .city(City.SEOUL)
             .district("행정구역")
+            .image(new MockMultipartFile("image", "content".getBytes(StandardCharsets.UTF_8)))
             .build();
 
         given(userRepository.findById(any())).willReturn(of(user));
+        given(s3UploadService.upload(any(), any())).willReturn(imageUrl);
 
         userService.update(user, userUpdateRequest);
 
         verify(userRepository).findById(any());
         verify(userRepository, never()).existsByNickname(any());
+        verify(s3UploadService).upload(any(), any());
         Assertions.assertAll(
             () -> assertThat(user.getNickname()).isEqualTo(userUpdateRequest.getNickname()),
             () -> assertThat(user.getUniversity()).isEqualTo(userUpdateRequest.getUniversity()),
             () -> assertThat(user.getCity()).isEqualTo(userUpdateRequest.getCity()),
-            () -> assertThat(user.getDistrict()).isEqualTo(userUpdateRequest.getDistrict())
+            () -> assertThat(user.getDistrict()).isEqualTo(userUpdateRequest.getDistrict()),
+            () -> assertThat(user.getImageUrl()).isEqualTo(imageUrl)
         );
     }
 


### PR DESCRIPTION
issue(#221) 해당 이슈 내용 작업 완료했습니다.

## 의논할 내용
* multipart/form-data 컨텐츠 타입을 사용할 경우 put, patch를 사용할 수 없습니다.
  * 큰 문제는 없습니다. 
* multipart/form-data 컨텐츠 타입을 사용할 경우 DTO의 MultipartFile가 필수 값이여야 합니다.
  * 내 정보 수정은 MultipartFile이 null일 경우도 존재합니다(이미지 변경을 하지 않는 경우).
  * **해당 내용은 이미지가 없는 경우 multipart/form-data 컨텐츠 타입을 제거해서 해결했습니다. 테스트, 문서도 이미지를 보내는 경우, 보내지 않는 경우를 따로 작성했습니다.**
* 이미지를 변경할 경우 기존의 이미지가 s3에서 삭제되지 않습니다.