### PR TITLE
[BE] 소켓 테스트 깨지는 문제 해결

### DIFF
--- a/server/momo-socket/src/main/java/com/momo/JpaRepositoryScan.java
+++ b/server/momo-socket/src/main/java/com/momo/JpaRepositoryScan.java
@@ -1,0 +1,16 @@
+package com.momo;
+
+import com.momo.group.search.GroupSearchEngine;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaRepositories(excludeFilters = @ComponentScan.Filter(
+    type = FilterType.ASSIGNABLE_TYPE,
+    classes = {GroupSearchEngine.class})
+)
+public class JpaRepositoryScan {
+
+}


### PR DESCRIPTION
Spring Data Elasticsearch 때문에 GroupSearch 빈이 중복되는 문제가 있었습니다. 이전 회의 때 말씀드린 방법으로 해결했는데, 좋은 방법은 아닌 듯 합니다. 지금 하는 작업(프로젝트 아키텍처 개선)을 진행하면서 이 문제도 해결해보겠습니다!

`소켓 채팅 테스트`가 깨지는 다른 문제가 있는 것 같습니다. 확인 부탁드려요~

이 브랜치에서 작업하셔도 괜찮습니다:)